### PR TITLE
Require graphql

### DIFF
--- a/lib/apollo_upload_server/upload.rb
+++ b/lib/apollo_upload_server/upload.rb
@@ -1,3 +1,5 @@
+require 'graphql'
+
 module ApolloUploadServer
   Upload = GraphQL::ScalarType.define do
     name 'Upload'

--- a/spec/apollo_upload_server/upload_spec.rb
+++ b/spec/apollo_upload_server/upload_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+require 'apollo_upload_server/upload'
+
+RSpec.describe ApolloUploadServer::Upload do
+
+  describe '#coerce_input' do
+    it { expect(described_class.coerce_input('test')).to eq 'test' }
+  end
+
+  describe '#coerce_result' do
+    it { expect(described_class.coerce_result('test')).to eq 'test' }
+  end
+end


### PR DESCRIPTION
Closes #4 

Thought I'd make a spec for the upload ScalarType. It's very simplistic, and I'm not sure if it properly specs Upload, but it runs and will catch if the requirement statement is left out another time :)