### PR TITLE
Update the upload type to use the class-based DSL

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     apollo_upload_server (2.0.0.beta.2)
-      graphql (~> 1.7)
+      graphql (>= 1.8)
       rails (>= 4.2)
 
 GEM
@@ -103,19 +103,19 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rake (10.5.0)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -141,4 +141,4 @@ DEPENDENCIES
   rspec (~> 3.5)
 
 BUNDLED WITH
-   1.17.3
+   1.16.0

--- a/apollo_upload_server.gemspec
+++ b/apollo_upload_server.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rails', '>= 4.2'
-  spec.add_dependency 'graphql', '~> 1.7'
+  spec.add_dependency 'graphql', '>= 1.8'
 
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/apollo_upload_server/upload.rb
+++ b/lib/apollo_upload_server/upload.rb
@@ -3,10 +3,15 @@
 require 'graphql'
 
 module ApolloUploadServer
-  Upload = GraphQL::ScalarType.define do
-    name 'Upload'
+  class Upload < GraphQL::Schema::Scalar
+    graphql_name "Upload"
 
-    coerce_input ->(value, _ctx) { value }
-    coerce_result ->(value, _ctx) { value }
+    def self.coerce_input(value, _ctx)
+      value
+    end
+
+    def self.coerse_result(value, _ctx)
+      value
+    end
   end
 end

--- a/spec/apollo_upload_server/upload_spec.rb
+++ b/spec/apollo_upload_server/upload_spec.rb
@@ -2,12 +2,13 @@ require 'spec_helper'
 require 'apollo_upload_server/upload'
 
 RSpec.describe ApolloUploadServer::Upload do
+  let(:ctx) { {} }
 
   describe '#coerce_input' do
-    it { expect(described_class.coerce_input('test')).to eq 'test' }
+    it { expect(described_class.coerce_input('test', ctx)).to eq 'test' }
   end
 
   describe '#coerce_result' do
-    it { expect(described_class.coerce_result('test')).to eq 'test' }
+    it { expect(described_class.coerce_result('test', ctx)).to eq 'test' }
   end
 end


### PR DESCRIPTION
This Pull request upgrades the type definition to use the class-based DSL.

I just followed the [guide](http://graphql-ruby.org/type_definitions/scalars.html#custom-scalars), but it adds the `context` as an argument, so this might be a breaking change for some.

What it allows now though is for users of the gem to create types that inherit from the `Upload` base type and do file validations easily like this:
```ruby
class CSVUpload < ApolloUploadServer::Upload
  def coerce_input(value, ctx)
    # custom code goes here
    super
  end

  def coerce_result(value, ctx)
    # same
    super    
  end
end
```

Let me know what you think!