### PR TITLE
fix typo

### DIFF
--- a/lib/apollo_upload_server/upload.rb
+++ b/lib/apollo_upload_server/upload.rb
@@ -10,7 +10,7 @@ module ApolloUploadServer
       value
     end
 
-    def self.coerse_result(value, _ctx)
+    def self.coerce_result(value, _ctx)
       value
     end
   end


### PR DESCRIPTION
Hi, thank you for the great gem!
I found a tiny typo.
GraphQL::Schema::Scalar has `coerce_input(value, _ctx)` and `coerce_result(value, _ctx)` as class method now.

https://github.com/rmosolgo/graphql-ruby/blob/120ec5e5fd6c9d485f57479cb3861ca1c4bb4a84/lib/graphql/schema/scalar.rb#L13
