### PR TITLE
Raise GraphQL::CoercionError if Upload is invalid

### DIFF
--- a/lib/apollo_upload_server/upload.rb
+++ b/lib/apollo_upload_server/upload.rb
@@ -7,6 +7,8 @@ module ApolloUploadServer
     graphql_name "Upload"
 
     def self.coerce_input(value, _ctx)
+      raise GraphQL::CoercionError, "#{value.inspect} is not a valid upload" unless value.is_a?(::ApolloUploadServer::Wrappers::UploadedFile)
+
       value
     end
 

--- a/spec/apollo_upload_server/upload_spec.rb
+++ b/spec/apollo_upload_server/upload_spec.rb
@@ -5,7 +5,12 @@ RSpec.describe ApolloUploadServer::Upload do
   let(:ctx) { {} }
 
   describe '#coerce_input' do
-    it { expect(described_class.coerce_input('test', ctx)).to eq 'test' }
+    let(:uploaded_file) { ApolloUploadServer::Wrappers::UploadedFile.new('test') }
+
+    specify do
+      expect(described_class.coerce_input(uploaded_file, ctx)).to eq(uploaded_file)
+      expect { described_class.coerce_input('test', ctx) }.to raise_error(GraphQL::CoercionError)
+    end
   end
 
   describe '#coerce_result' do


### PR DESCRIPTION
This prevents a mutation from receiving invalid input, for example, a `String` when a user posts data like this.

```
mutation {
  myUpload(input: { file: "" }) {
    ...
  }
}
```