### PR TITLE
Removed the skelton executables from gem package

### DIFF
--- a/apollo_upload_server.gemspec
+++ b/apollo_upload_server.gemspec
@@ -16,8 +16,6 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
-  spec.bindir        = 'bin'
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rails', '>= 4.2'


### PR DESCRIPTION
Hi, I did install this gem. I found the this gem contained the skelton code generated by `bundle gem`.

This executable will put the user `PATH` globally. Is it the intentional? 