### PR TITLE
only require the part of rails that's needed

### DIFF
--- a/apollo_upload_server.gemspec
+++ b/apollo_upload_server.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rails', '>= 4.2'
+  spec.add_dependency 'actionpack', '>= 4.2'
   spec.add_dependency 'graphql', '>= 1.8'
 
   spec.add_development_dependency 'bundler', '~> 2.1'


### PR DESCRIPTION
to facilitate the ability for a project to do the same

https://andycroll.com/ruby/turn-off-the-bits-of-rails-you-dont-use/