### PR TITLE
Fix to execute call method even when content-type is multipart/form-data

### DIFF
--- a/lib/apollo_upload_server/middleware.rb
+++ b/lib/apollo_upload_server/middleware.rb
@@ -20,6 +20,8 @@ module ApolloUploadServer
           request.update_param(key, value)
         end
       end
+
+      @app.call(env)
     end
   end
 end

--- a/spec/apollo_upload_server/middleware_spec.rb
+++ b/spec/apollo_upload_server/middleware_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+require 'action_dispatch'
+require 'apollo_upload_server/middleware'
+
+describe ApolloUploadServer::Middleware do
+  describe '#call' do
+    let(:app) do
+      Rack::Builder.new do
+        use ApolloUploadServer::Middleware
+        run ->(_env) { [200, { 'Content-Type' => 'text/plain' }, 'Hello, World.'] }
+      end
+    end
+
+    context "when CONTENT_TYPE is 'multipart/form-data'" do
+      subject do
+        Rack::MockRequest.new(app).post('/', { 'CONTENT_TYPE' => 'multipart/form-data', input: 'operations=foo&map=bar' })
+      end
+
+      it { expect(subject.status).to eq(200) }
+    end
+
+    context "when CONTENT_TYPE is not 'multipart/form-data'" do
+      subject do
+        Rack::MockRequest.new(app).post('/', { 'CONTENT_TYPE' => 'text/pain' })
+      end
+
+      it { expect(subject.status).to eq(200) }
+    end
+  end
+end


### PR DESCRIPTION
In version 2.0.4, middleware returns nil when the content-type is 'multipart/form-data'.  I think that the middleware should execute call method regardless of the content-type.