### PR TITLE
Add strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,38 @@ Use `ApolloUploadServer::Upload` type for your file as input field:
 
 That's all folks!
 
+## Configuration
+
+The following configuration options are supported:
+
+### Strict Mode
+
+This can be set on `ApolloUploadServer::Middleware`:
+
+```ruby
+ApolloUploadServer::Middleware.strict_mode = true
+```
+
+Doing so ensures that all mapped array values are present in the input. If this
+is set to `true`, then for following request:
+
+```json
+{
+  "operations": {
+    "query": "mutation { ... }",
+    "operationName": "SomeOperation",
+    "variables": {
+      "input": { "id": "123", "avatars": [null, null] }
+    }
+  }
+}
+```
+
+A mapping for `variables.input.avatars.0` or `variables.input.avatars.1`, will work, but one for
+`variables.input.avatars.100` will not, and will raise an error.
+
+In strict mode, passing empty destination arrays will always fail.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/jetruby/apollo_upload_server-ruby. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

--- a/lib/apollo_upload_server/graphql_data_builder.rb
+++ b/lib/apollo_upload_server/graphql_data_builder.rb
@@ -5,6 +5,12 @@ require 'apollo_upload_server/wrappers/uploaded_file'
 
 module ApolloUploadServer
   class GraphQLDataBuilder
+    OutOfBounds = Class.new(ArgumentError)
+
+    def initialize(strict_mode: false)
+      @strict_mode = strict_mode
+    end
+
     def call(params)
       operations = safe_json_parse(params['operations'])
       file_mapper = safe_json_parse(params['map'])
@@ -36,15 +42,24 @@ module ApolloUploadServer
 
     def multiple_transformation(file_mapper, operations, params)
       operations = operations.dup
+
       file_mapper.each do |file_index, paths|
         paths.each do |path|
           splited_path = path.split('.')
           # dig from second to penultimate key, and merge last key with value as file to operation with first key index
           field = operations[splited_path.first.to_i].dig(*splited_path[1..-2])
+
           assign_file(field, splited_path, params[file_index])
         end
       end
       operations
+    end
+
+    def verify_array_index!(path, index, size)
+      return unless @strict_mode
+      return if 0 <= index && index < size
+
+      raise OutOfBounds, "Path #{path.join('.')} maps to out-of-bounds index: #{index}"
     end
 
     def safe_json_parse(data)
@@ -73,8 +88,18 @@ module ApolloUploadServer
       if field.is_a? Hash
         field.merge!(splited_path.last => wrapped_file)
       elsif field.is_a? Array
-        field[splited_path.last.to_i] = wrapped_file
+        index = parse_array_index(splited_path)
+        verify_array_index!(splited_path, index, field.size)
+        field[index] = wrapped_file
       end
+    end
+
+    def parse_array_index(path)
+      return path.last.to_i unless @strict_mode
+
+      Integer(path.last)
+    rescue ArgumentError
+      raise OutOfBounds, "Not a valid path to an array value: #{path.join('.')}"
     end
   end
 end

--- a/lib/apollo_upload_server/middleware.rb
+++ b/lib/apollo_upload_server/middleware.rb
@@ -1,7 +1,15 @@
 require 'apollo_upload_server/graphql_data_builder'
+require "active_support/configurable"
 
 module ApolloUploadServer
   class Middleware
+    include ActiveSupport::Configurable
+
+    # Strict mode requires that all mapped files are present in the mapping arrays.
+    config_accessor :strict_mode do
+      false
+    end
+
     def initialize(app)
       @app = app
     end
@@ -15,7 +23,7 @@ module ApolloUploadServer
       params = request.params
 
       if params['operations'].present? && params['map'].present?
-        result = GraphQLDataBuilder.new.call(request.params)
+        result = GraphQLDataBuilder.new(strict_mode: self.class.strict_mode).call(request.params)
         result&.each do |key, value|
           request.update_param(key, value)
         end

--- a/spec/apollo_upload_server/middleware_spec.rb
+++ b/spec/apollo_upload_server/middleware_spec.rb
@@ -3,6 +3,12 @@ require 'action_dispatch'
 require 'apollo_upload_server/middleware'
 
 describe ApolloUploadServer::Middleware do
+  around do |example|
+    mode = described_class.strict_mode
+    example.run
+    described_class.strict_mode = mode
+  end
+
   describe '#call' do
     let(:app) do
       Rack::Builder.new do
@@ -21,10 +27,26 @@ describe ApolloUploadServer::Middleware do
 
     context "when CONTENT_TYPE is not 'multipart/form-data'" do
       subject do
-        Rack::MockRequest.new(app).post('/', { 'CONTENT_TYPE' => 'text/pain' })
+        Rack::MockRequest.new(app).post('/', { 'CONTENT_TYPE' => 'text/plain' })
       end
 
       it { expect(subject.status).to eq(200) }
+    end
+
+    context 'when configured to run in strict mode' do
+      before do
+        described_class.strict_mode = true
+      end
+
+      subject do
+        Rack::MockRequest.new(app).post('/', { 'CONTENT_TYPE' => 'multipart/form-data', input: 'operations=foo&map=bar' })
+      end
+
+      it 'propagates this setting to the data builder' do
+        expect(ApolloUploadServer::GraphQLDataBuilder).to receive(:new).with(strict_mode: true).and_call_original
+
+        subject
+      end
     end
   end
 end


### PR DESCRIPTION
Strict mode is a new configuration setting applied to the middleware:

```ruby
ApolloUploadServer::Middleware.strict_mode = true
```

Applying this setting changes the behavior of this module in the
following two ways:

- array mappings must be integers
- array mappings must be in bounds in the destination array

Applying these checks ensures that requests are not able to create large
arrays using small input.