### PR TITLE
Remove unnecessary ApolloUploadServer::Upload overrides

### DIFF
--- a/lib/apollo_upload_server/upload.rb
+++ b/lib/apollo_upload_server/upload.rb
@@ -7,13 +7,9 @@ module ApolloUploadServer
     graphql_name "Upload"
 
     def self.coerce_input(value, _ctx)
-      raise GraphQL::CoercionError, "#{value.inspect} is not a valid upload" unless value.nil? || value.is_a?(::ApolloUploadServer::Wrappers::UploadedFile)
+      return super if value.nil? || value.is_a?(::ApolloUploadServer::Wrappers::UploadedFile)
 
-      value
-    end
-
-    def self.coerce_result(value, _ctx)
-      value
+      raise GraphQL::CoercionError, "#{value.inspect} is not a valid upload"
     end
   end
 end


### PR DESCRIPTION
This PR is meant to simplify the `ApolloUploadServer::Upload` class and clarify its relationship to its parent class by: 

- removing the `ApolloUploadServer::Upload::coerce_result` method given that the desired behaviour is already provided by the inherited method.
- refactoring the `ApolloUploadServer::Upload::coerce_input` method so that we are more explicit with regards to how this method implements behaviour that differs from that defined in the inherited method.
