### PR TITLE
Stop swallowing JSON parse errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/bundle/

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ In strict mode, passing empty destination arrays will always fail.
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/jetruby/apollo_upload_server-ruby. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
+Tests can be run via `bundle exec rspec`.
+
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/lib/apollo_upload_server/graphql_data_builder.rb
+++ b/lib/apollo_upload_server/graphql_data_builder.rb
@@ -12,8 +12,8 @@ module ApolloUploadServer
     end
 
     def call(params)
-      operations = safe_json_parse(params['operations'])
-      file_mapper = safe_json_parse(params['map'])
+      operations = JSON.parse(params['operations'])
+      file_mapper = JSON.parse(params['map'])
 
       return nil if operations.nil? || file_mapper.nil?
       if operations.is_a?(Hash)
@@ -60,12 +60,6 @@ module ApolloUploadServer
       return if 0 <= index && index < size
 
       raise OutOfBounds, "Path #{path.join('.')} maps to out-of-bounds index: #{index}"
-    end
-
-    def safe_json_parse(data)
-      JSON.parse(data)
-    rescue JSON::ParserError
-      raise JSON::ParserError, "Malformed JSON in multipart form data"
     end
 
     def get_parent_field(operations, splited_path)

--- a/lib/apollo_upload_server/graphql_data_builder.rb
+++ b/lib/apollo_upload_server/graphql_data_builder.rb
@@ -65,7 +65,7 @@ module ApolloUploadServer
     def safe_json_parse(data)
       JSON.parse(data)
     rescue JSON::ParserError
-      nil
+      raise JSON::ParserError, "Malformed JSON in multipart form data"
     end
 
     def get_parent_field(operations, splited_path)

--- a/spec/apollo_upload_server/middleware_spec.rb
+++ b/spec/apollo_upload_server/middleware_spec.rb
@@ -19,7 +19,7 @@ describe ApolloUploadServer::Middleware do
 
     context "when CONTENT_TYPE is 'multipart/form-data'" do
       subject do
-        Rack::MockRequest.new(app).post('/', { 'CONTENT_TYPE' => 'multipart/form-data', input: 'operations=foo&map=bar' })
+        Rack::MockRequest.new(app).post('/', { 'CONTENT_TYPE' => 'multipart/form-data', input: 'operations={}&map={}' })
       end
 
       it { expect(subject.status).to eq(200) }
@@ -39,7 +39,7 @@ describe ApolloUploadServer::Middleware do
       end
 
       subject do
-        Rack::MockRequest.new(app).post('/', { 'CONTENT_TYPE' => 'multipart/form-data', input: 'operations=foo&map=bar' })
+        Rack::MockRequest.new(app).post('/', { 'CONTENT_TYPE' => 'multipart/form-data', input: 'operations={}&map={}' })
       end
 
       it 'propagates this setting to the data builder' do


### PR DESCRIPTION
If unparseable JSON is provided, the library should fail loudly rather than ignoring the input.

Looking through the blame, I couldn't find any specific reason why `safe_json_parse` is meant to be safe -- in fact, because it swallows up errors and pretends that there's no problem, it made things very confusing to diagnose.

Let me know if you'd like me to take this in any particular direction and I'm happy to update the PR.