### PR TITLE
Exclude Gemfile.lock from gem package to avoid false positive security alerts

### DIFF
--- a/apollo_upload_server.gemspec
+++ b/apollo_upload_server.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
+    f.match(%r{^(test|spec|features)/}) || f == "Gemfile.lock"
   end
   spec.require_paths = ['lib']
 


### PR DESCRIPTION
## Summary

Exclude `Gemfile.lock` from the gem package to prevent false positive vulnerability alerts from security scanners like Amazon Inspector.

## Problem

Security scanners (e.g., Amazon ECR Enhanced Scanning, Amazon Inspector) scan all files in container images, including `Gemfile.lock` files inside gem packages. The development `Gemfile.lock` in this gem references older versions of dependencies (e.g., `actionpack 7.0.4`), which triggers vulnerability alerts even though applications using this gem typically have newer, patched versions.

Reference: https://tech.medpeer.co.jp/entry/ecr-enhanced-scanning-false-positive

## Solution

Exclude `Gemfile.lock` from `spec.files` in the gemspec, as it's only used during gem development and not needed at runtime.
